### PR TITLE
docs: rebrand Authority Portal to Data Space Portal

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -30,15 +30,15 @@ Feel free to edit this release checklist in-progress depending on what tasks nee
     - [ ] Merge the `release-prep` PR.
 - [ ] Wait for the main branch to be green.
 - [ ] Create a release and re-use the changelog section as release description, and the version as title.
-- [ ] Create a release in the [Authority Portal EE](https://github.com/sovity/authority-portal-ee) repository.
+- [ ] Create a release in the [Data Space Portal EE](https://github.com/sovity/dataspace-portal-ee) repository.
     - [ ] `release-prep` PR:
-        - [ ] Copy the [Keycloak themes](https://github.com/sovity/authority-portal/tree/main/authority-portal-keycloak) for all flavors
+        - [ ] Copy the [Keycloak themes](https://github.com/sovity/dataspace-portal/tree/main/authority-portal-keycloak) for all flavors
           from here to the EE repository.
         - [ ] Copy
-          the [OAuth2 proxy templates](https://github.com/sovity/authority-portal/tree/main/authority-portal-oauth2-proxy)
+          the [OAuth2 proxy templates](https://github.com/sovity/dataspace-portal/tree/main/authority-portal-oauth2-proxy)
           from here to the EE repository.
         - [ ] Copy
-          the [realm.json](https://github.com/sovity/authority-portal/blob/main/authority-portal-backend/authority-portal-quarkus/src/main/resources/realm.json) files for all flavors
+          the [realm.json](https://github.com/sovity/dataspace-portal/blob/main/authority-portal-backend/authority-portal-quarkus/src/main/resources/realm.json) files for all flavors
           from here to the EE repository.
         - [ ] Update the Catalog Crawler image in EE's `.env`.
         - [ ] Link this release in the EE changelog.
@@ -49,6 +49,6 @@ Feel free to edit this release checklist in-progress depending on what tasks nee
 - [ ] Notify the deployment team, which will send a message to the customer about the new release.
 - [ ] `release-cleanup` PR:
     - [ ] Revisit the changed list of tasks and compare it
-      with [.github/ISSUE_TEMPLATE/release.md](https://github.com/sovity/authority-portal/blob/main/.github/ISSUE_TEMPLATE/release.md).
+      with [.github/ISSUE_TEMPLATE/release.md](https://github.com/sovity/dataspace-portal/blob/main/.github/ISSUE_TEMPLATE/release.md).
       Apply changes where it makes sense.
     - [ ] Merge the `release-cleanup` PR.

--- a/.github/markdown-link-checker-config.jq
+++ b/.github/markdown-link-checker-config.jq
@@ -8,7 +8,7 @@
     {"pattern": "https://(.*?)\\.azure\\.sovity\\.io"},
     {"pattern": "http://edc[0-9]*:"},
     {"pattern": "https://test-connector.hosting-environment.io"},
-    {"pattern": "https://github.com/sovity/authority-portal-ee"}
+    {"pattern": "https://github.com/sovity/dataspace-portal-ee"}
   ],
   "replacementPatterns": [
     {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The Data Space Portal is not just about managing participants. It also provides 
 
 As a Dataspace administration tool, the Data Space Portal necessitates technical connections with other dataspace components, including the CaaS component. This integration ensures a smooth and efficient operation, enhancing the overall user experience.
 
+<b>Note:</b> This component was previously known as Authority Portal (AP) and has been renamed to Data Space Portal (DSPortal). The functionality remains unchanged.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 <img src="https://raw.githubusercontent.com/sovity/edc-ui/main/src/assets/images/sovity_logo.svg" alt="Logo" width="300">
 </a>
 
-<h3 align="center">Authority Portal</h3>
+<h3 align="center">Data Space Portal</h3>
 <p align="center" style="padding-bottom:16px">
-Manage your Dataspace
+ Collaboration and governance for all participants
 <br />
 <a href="https://github.com/sovity/authority-portal/issues/new?assignees=&labels=kind%2Fbug&projects=&template=bug_report.yaml">Report Bug</a>
 ·
@@ -21,11 +21,11 @@ Manage your Dataspace
 
 ## About The Project
 
-The **Authority Portal** is an open-source Software as a Service (SaaS) solution designed to streamline the management of your Dataspace. This innovative tool serves as a comprehensive Dataspace Administration Tool, offering a platform where you can seamlessly invite organizations and their users to participate in your Dataspace.
+The **Data Space Portal** is an open-source Software as a Service (SaaS) solution designed to streamline the management of your Dataspace. This innovative tool serves as a comprehensive Dataspace Administration Tool, offering a platform where you can seamlessly invite organizations and their users to participate in your Dataspace.
 
-The Authority Portal is not just about managing participants. It also provides multiple avenues to add or acquire connectors and service partners. These partners can offer their own Connector-as-a-Service (CaaS), extending the functionality and versatility of your Dataspace.
+The Data Space Portal is not just about managing participants. It also provides multiple avenues to add or acquire connectors and service partners. These partners can offer their own Connector-as-a-Service (CaaS), extending the functionality and versatility of your Dataspace.
 
-As a Dataspace administration tool, the Authority Portal necessitates technical connections with other dataspace components, including the CaaS component. This integration ensures a smooth and efficient operation, enhancing the overall user experience.
+As a Dataspace administration tool, the Data Space Portal necessitates technical connections with other dataspace components, including the CaaS component. This integration ensures a smooth and efficient operation, enhancing the overall user experience.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -73,7 +73,7 @@ see [Frontend Local E2E Development](authority-portal-frontend/README.md#local-e
 
 ### Productive Deployment Guide
 
-There is a guide on [How to deploy the Authority Portal for Production](docs/deployment-guide/goals/production/README.md) in this
+There is a guide on [How to deploy the Data Space Portal for Production](docs/deployment-guide/goals/production/README.md) in this
 repository.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -86,6 +86,6 @@ See [`LICENSE`](./LICENSE) for more information.
 
 ## Contact
 
-If you're interested in deploying the Authority Portal for productive use, we at sovity are ready to assist you. Our team is committed to providing the support you need to make the most of this powerful tool. Contact us today to learn more about how the Authority Portal can transform your dataspace management: contact@sovity.de
+If you're interested in deploying the Data Space Portal for productive use, we at sovity are ready to assist you. Our team is committed to providing the support you need to make the most of this powerful tool. Contact us today to learn more about how the Data Space Portal can transform your dataspace management: contact@sovity.de
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/authority-portal-backend/README.md
+++ b/authority-portal-backend/README.md
@@ -9,7 +9,7 @@
 <img src="https://raw.githubusercontent.com/sovity/edc-ui/main/src/assets/images/sovity_logo.svg" alt="Logo" width="300">
 </a>
 
-<h3 align="center">Authority Portal</h3>
+<h3 align="center">Data Space Portal</h3>
 <p align="center" style="padding-bottom:16px">
 Backend + Frontend + E2E Tests
 <br />
@@ -21,7 +21,7 @@ Backend + Frontend + E2E Tests
 
 ## About This Component
 
-Backend for the Authority Portal. Built with Quarkus, Kotlin and JOOQ.
+Backend for the Data Space Portal. Built with Quarkus, Kotlin and JOOQ.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/authority-portal-backend/authority-portal-api-client-ts/README.md
+++ b/authority-portal-backend/authority-portal-api-client-ts/README.md
@@ -5,7 +5,7 @@
     <img src="https://raw.githubusercontent.com/sovity/edc-ui/main/src/assets/images/sovity_logo.svg" alt="Logo" width="300">
   </a>
 
-<h3 align="center">Authority Portal API TypeScript Client Library</h3>
+<h3 align="center">Data Space Portal API TypeScript Client Library</h3>
 
   <p align="center">
     <a href="https://github.com/sovity/authority-portal/issues/new?template=bug_report.md">Report Bug</a>
@@ -16,7 +16,7 @@
 
 ## About this component
 
-TypeScript Client Library to access APIs of our Authority Portal Backend.
+TypeScript Client Library to access APIs of our Data Space Portal Backend.
 
 ## How to install
 
@@ -28,7 +28,7 @@ npm i --save @sovity.de/authority-portal-client
 
 ## How to use
 
-Configure your Authority Portal Client and use endpoints of our Authority Portal
+Configure your Data Space Portal Client and use endpoints of our Data Space Portal
 API:
 
 ```typescript

--- a/authority-portal-backend/authority-portal-api/README.md
+++ b/authority-portal-backend/authority-portal-api/README.md
@@ -5,7 +5,7 @@
     <img src="https://raw.githubusercontent.com/sovity/edc-ui/main/src/assets/images/sovity_logo.svg" alt="Logo" width="300">
   </a>
 
-<h3 align="center">Authority Portal API Specification</h3>
+<h3 align="center">Data Space Portal API Specification</h3>
 
   <p align="center">
     <a href="https://github.com/sovity/authority-portal/issues/new?template=bug_report.md">Report Bug</a>
@@ -16,7 +16,7 @@
 
 ## About this component
 
-Specification of Authority Portal API endpoints, for example endpoints for the Authority Portal UI.
+Specification of Data Space Portal API endpoints, for example endpoints for the Data Space Portal UI.
 
 ## License
 

--- a/authority-portal-backend/catalog-crawler/README.md
+++ b/authority-portal-backend/catalog-crawler/README.md
@@ -19,14 +19,14 @@
 The Catalog Crawler is an additional deployment unit needed to determine the online status of registered connectors and populate the Data Catalog:
 
 - It is a modified EDC connector with the task to crawl the other connectors' public data offers.
-- It periodically checks the Authority Portal's connector list for its environment.
+- It periodically checks the Data Space Portal's connector list for its environment.
 - It crawls the given connectors in regular intervals.
-- It writes the data offers and connector statuses into the Authority Portal DB.
-- Each environment configured in the Authority Portal requires its own Catalog Crawler with credentials for that environment's DAPS.
+- It writes the data offers and connector statuses into the Data Space Portal DB.
+- Each environment configured in the Data Space Portal requires its own Catalog Crawler with credentials for that environment's DAPS.
 
 ## Why does this component exist?
 
-The Authority Portal uses a non-EDC stack and thus it cannot read the catalogs of participating connectors directly.
+The Data Space Portal uses a non-EDC stack and thus it cannot read the catalogs of participating connectors directly.
 
 ## Deployment
 

--- a/authority-portal-backend/catalog-crawler/README.md
+++ b/authority-portal-backend/catalog-crawler/README.md
@@ -5,7 +5,7 @@
     <img src="https://raw.githubusercontent.com/sovity/edc-ui/main/src/assets/images/sovity_logo.svg" alt="Logo" width="300">
   </a>
 
-<h3 align="center">EDC-Connector Extension:<br />Catalog Crawler</h3>
+<h3 align="center">Catalog Crawler</h3>
 
   <p align="center">
     <a href="https://github.com/sovity/authority-portal/issues/new?assignees=&labels=kind%2Fbug&projects=&template=bug_report.yaml">Report Bug</a>

--- a/authority-portal-frontend/README.md
+++ b/authority-portal-frontend/README.md
@@ -16,10 +16,10 @@
 <img src="https://raw.githubusercontent.com/sovity/edc-ui/main/src/assets/images/sovity_logo.svg" alt="Logo" width="300">
 </a>
 
-<h3 align="center">Authority Portal</h3>
+<h3 align="center">Data Space Portal</h3>
 
   <p align="center">
-    Frontend (UI) of Authority Portal
+    Frontend (UI) of Data Space Portal
     <br />
     <a href="https://github.com/sovity/authority-portal/issues">Report Bug</a>
     ·
@@ -52,7 +52,7 @@
 
 ## About This Component
 
-Frontend for sovity's Dataspace Authority Portal, written in Angular with
+Frontend for sovity's Dataspace Data Space Portal, written in Angular with
 TypeScript, NGXS State Management and TailwindCSS Framework.
 
 <p align="right">(<a href="#readme-top">back to top</a>)

--- a/authority-portal-keycloak/README.md
+++ b/authority-portal-keycloak/README.md
@@ -2,7 +2,7 @@
 <br />
 <div align="center">
 
-<h3 align="center">Authority Portal</h3>
+<h3 align="center">Data Space Portal</h3>
 <p align="center" style="padding-bottom:16px">
 Custom Keycloak Theme
 <br />
@@ -21,11 +21,11 @@ An MDS-Themed Kecyloak.
 
 ## Why does this component exist?
 
-The Authority Portal uses the Keycloak Login Page. This is due to identity federation and SSO.
+The Data Space Portal uses the Keycloak Login Page. This is due to identity federation and SSO.
 
 For consistency, the MDS wanted a custom theming.
 
-Registration processes, however, will be fully handled by the Authority Portal.
+Registration processes, however, will be fully handled by the Data Space Portal.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/authority-portal-oauth2-proxy/README.md
+++ b/authority-portal-oauth2-proxy/README.md
@@ -2,7 +2,7 @@
 <br />
 <div align="center">
 
-<h3 align="center">Authority Portal</h3>
+<h3 align="center">Data Space Portal</h3>
 <p align="center" style="padding-bottom:16px">
 Custom OAuth2 proxy templates
 <br />

--- a/docs/deployment-guide/goals/production/README.md
+++ b/docs/deployment-guide/goals/production/README.md
@@ -2,12 +2,12 @@
 icon: square-dashed-circle-plus
 ---
 
-Deploying the Authority Portal in Production
+Deploying the Data Space Portal in Production
 ============
 
 ## About this Guide
 
-This is a productive deployment guide for deploying the Authority Portal from scratch.
+This is a productive deployment guide for deploying the Data Space Portal from scratch.
 
 ## Prerequisites
 
@@ -53,8 +53,8 @@ The respective compatible versions can be found in the [CHANGELOG.md](../../../.
 | Keycloak Deployment                   | Version 24.0.4 or compatible version                                                              |
 | OAuth2 Proxy                          | quay.io/oauth2-proxy/oauth2-proxy:7.5.0                                                           |
 | Caddy behind OAuth2 Proxy             | caddy:2.7                                                                                         |
-| Authority Portal Backend              | authority-portal-backend, see [CHANGELOG.md](../../../../CHANGELOG.md) for compatible versions.   |
-| Authority Portal Frontend             | authority-portal-frontend, see  [CHANGELOG.md](../../../../CHANGELOG.md) for compatible versions. |
+| Data Space Portal Backend              | authority-portal-backend, see [CHANGELOG.md](../../../../CHANGELOG.md) for compatible versions.   |
+| Data Space Portal Frontend             | authority-portal-frontend, see  [CHANGELOG.md](../../../../CHANGELOG.md) for compatible versions. |
 | Catalog Crawler (one per environment) | authority-portal-crawler, see [CHANGELOG.md](../../../../CHANGELOG.md) for compatible versions.   |
 | Postgresql                            | Version 16 or compatible version                                                                  |
 
@@ -62,12 +62,12 @@ The respective compatible versions can be found in the [CHANGELOG.md](../../../.
 
 #### Reverse Proxy / Ingress
 
-- Authority Portal needs to be deployed with TLS/HTTPS.
-- The domain under which the Authority Portal should be reachable on the internet will be referred to as `[AP_FQDN]` in this
+- Data Space Portal needs to be deployed with TLS/HTTPS.
+- The domain under which the Data Space Portal should be reachable on the internet will be referred to as `[DSPORTAL_FQDN]` in this
   guide.
 - Path mapping: 
-  - Frontend: `https://[AP_FQDN]` -> `caddy:8080` -> `frontend:8080`
-  - Backend: `https://[AP_FQDN]/api` -> `caddy:8080` -> `oauth2-proxy:8080` -> `caddy:8081` -> `backend:8080/api`
+  - Frontend: `https://[DSPORTAL_FQDN]` -> `caddy:8080` -> `frontend:8080`
+  - Backend: `https://[DSPORTAL_FQDN]/api` -> `caddy:8080` -> `oauth2-proxy:8080` -> `caddy:8081` -> `backend:8080/api`
 
 #### Keycloak IAM Deployment
 
@@ -82,7 +82,7 @@ The respective compatible versions can be found in the [CHANGELOG.md](../../../.
 - Consider consulting Keycloak's [server administration guide](https://www.keycloak.org/docs/latest/server_admin/).
 - You need to have a running Keycloak with the aforementioned compatible version.
 - The domain under which the Keycloak should be reachable on the internet will be referred to as `[KC_FQDN]` in this
-  guide and should differ from the `[AP_FQDN]`.
+  guide and should differ from the `[DSPORTAL_FQDN]`.
 - The steps to set up the realm are the following
   - sovity theme
       1. Copy [sovity-theme](../../../../authority-portal-keycloak/sovity-theme) directory to `{keycloakRoot}/themes/` directory
@@ -93,7 +93,7 @@ The respective compatible versions can be found in the [CHANGELOG.md](../../../.
           - `Valid Redirect URIs`: (Relative) callback URL of auth proxy, e.g. `/oauth2/callback`
           - `Valid post logout redirect URIs`: `/*`
       4. Adjust settings for `authority-portal-client` client (Clients > `authority-portal-client` > Settings)
-          - `Root URL`: URL of the authority portal, e.g. `https://authority-portal.example.url`
+          - `Root URL`: URL of the Data Space Portal, e.g. `https://authority-portal.example.url`
           - `Home URL`: (Most likely) same as `Root URL`
       5. Regenerate client secrets for `oauth2-proxy` and `authority-portal-client` clients
           - Clients > `[client]` > Credentials > Regenerate (Client secret)
@@ -112,7 +112,7 @@ The respective compatible versions can be found in the [CHANGELOG.md](../../../.
        - `Valid Redirect URIs`: (Relative) callback URL of auth proxy, e.g. `/oauth2/callback`
        - `Valid post logout redirect URIs`: `/*`
     4. Adjust settings for `authority-portal-client` client (Clients > `authority-portal-client` > Settings)
-       - `Root URL`: URL of the authority portal, e.g. `https://authority-portal.example.url`
+       - `Root URL`: URL of the Data Space Portal, e.g. `https://authority-portal.example.url`
        - `Home URL`: (Most likely) same as `Root URL`
     5. Regenerate client secrets for `oauth2-proxy` and `authority-portal-client` clients
        - Clients > `[client]` > Credentials > Regenerate (Client secret)
@@ -138,7 +138,7 @@ AUTH_PROXY_UPSTREAM_HOST: auth-proxy
 
 #### OAuth2 Proxy
 
-- The Authority Portal is meant to be deployed with an OAuth2 Proxy in front of the Portal Backend.
+- The Data Space Portal is meant to be deployed with an OAuth2 Proxy in front of the Portal Backend.
 - The OAuth2 Proxy should be configured to use the Keycloak (IAM) as OAuth2 Provider.
 - Copy the contents from [resources](../../../../authority-portal-oauth2-proxy/resources) to a directory the OAuth2 proxy can access (`CUSTOM_TEMPLATES_DIR`)
 
@@ -159,7 +159,7 @@ OAUTH2_PROXY_HTTP_ADDRESS: 0.0.0.0:8080
 OAUTH2_PROXY_PASS_ACCESS_TOKEN: "true"
 OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
 OAUTH2_PROXY_SHOW_DEBUG_ON_ERROR: "true"
-OAUTH2_PROXY_REDIRECT_URL: https://[AP_FQDN]/oauth2/callback
+OAUTH2_PROXY_REDIRECT_URL: https://[DSPORTAL_FQDN]/oauth2/callback
 OAUTH2_PROXY_SCOPE: openid profile
 OAUTH2_PROXY_WHITELIST_DOMAINS: [KC_FQDN]
 OAUTH2_PROXY_CUSTOM_TEMPLATES_DIR: [CUSTOM_TEMPLATES_DIR]
@@ -167,7 +167,7 @@ OAUTH2_PROXY_CUSTOM_TEMPLATES_DIR: [CUSTOM_TEMPLATES_DIR]
 
 #### Keycloak DAPS Client Creation
 
-The Authority Portal requires a client to register new connector certificates.
+The Data Space Portal requires a client to register new connector certificates.
 This client must have the following settings:
 
 - Section `Authentication flow` (Tab `Settings`)
@@ -181,7 +181,7 @@ This client must have the following settings:
   - `realm-management` > `view-clients` enabled
   - `realm-management` > `query-clients` enabled
 
-#### Authority Portal Backend
+#### Data Space Portal Backend
 
 - Image: `ghcr.io/sovity/authority-portal-backend`
 - Set environment variables according to the following documentation (mandatory, except log level)
@@ -204,7 +204,7 @@ quarkus.keycloak.admin-client.realm: "[KC_REALM]"
 # Keycloak Admin Client: Client ID
 quarkus.keycloak.admin-client.client-id: "authority-portal-client"
 # Keycloak Admin Client: Client secret
-quarkus.keycloak.admin-client.client-secret: "[AP_CLIENT_SECRET]"
+quarkus.keycloak.admin-client.client-secret: "[DSPORTAL_CLIENT_SECRET]"
 # Keycloak Admin Client: Grant type
 quarkus.keycloak.admin-client.grant-type: "CLIENT_CREDENTIALS"
 
@@ -226,16 +226,16 @@ authority-portal.caas.sovity.limit-per-organization: "1"
 quarkus.oidc-client.sovity.client-enabled: true
 
 # Must equal the root URL/home URl from the Keycloak configuration - see above)
-authority-portal.base-url: "https://[AP_FQDN]"
+authority-portal.base-url: "https://[DSPORTAL_FQDN]"
 
 # API key to protect config endpoints, like /api/config/log-level
-authority-portal.config.api-key: "[AP_CONFIG_API_KEY]"
+authority-portal.config.api-key: "[DSPORTAL_CONFIG_API_KEY]"
 
 # Invitation link expiration time in seconds. (Must equal the value in Keycloak configuration)
 authority-portal.invitation.expiration: "43200"
 
 # Environment Configuration
-# - Each Authority Portal can be configured with multiple environments, e.g. test, staging, prod, etc. 
+# - Each Data Space Portal can be configured with multiple environments, e.g. test, staging, prod, etc. 
 # - Following is an example configuration of the "test" environment.
 # - Please Note, that the environment "test" is mandatory
 
@@ -299,27 +299,27 @@ Example:
 curl -X PUT 'https://authority-portal.example.com/api/config/log-level?level=DEBUG' --header 'x-api-key: uYtR_wNsvXU4EbV9GioACnj!NHML_HRX'
 ```
 
-#### Authority Portal Frontend
+#### Data Space Portal Frontend
 
 - Image: `ghcr.io/sovity/authority-portal-frontend`
 - Set environment variables according to the following table (mandatory)
 
 ```yaml
-AUTHORITY_PORTAL_FRONTEND_BACKEND_URL: https://[AP_FQDN] # Authority Portal URL
-AUTHORITY_PORTAL_FRONTEND_LOGIN_URL: https://[AP_FQDN]/oauth2/start?rd=https%3A%2F%2F[AP_FQDN] # Auth Proxy: Login URL (with redirect to the Authority Portal)
+AUTHORITY_PORTAL_FRONTEND_BACKEND_URL: https://[DSPORTAL_FQDN] # Data Space Portal URL
+AUTHORITY_PORTAL_FRONTEND_LOGIN_URL: https://[DSPORTAL_FQDN]/oauth2/start?rd=https%3A%2F%2F[DSPORTAL_FQDN] # Auth Proxy: Login URL (with redirect to the Data Space Portal)
 # Following is the URL to signal the Auth Proxy to log out the user.
-# Example: https://[AP_FQDN]/oauth2/sign_out?rd=https%3A%2F%2F[KC_FQDN]%2Frealms%2F[KC_REALM]l%2Fprotocol%2Fopenid-connect%2Flogout%3Fclient_id%3Doauth2-proxy%26post_logout_redirect_uri%3Dhttps%253A%252F%252F[AP_FQDN]
+# Example: https://[DSPORTAL_FQDN]/oauth2/sign_out?rd=https%3A%2F%2F[KC_FQDN]%2Frealms%2F[KC_REALM]l%2Fprotocol%2Fopenid-connect%2Flogout%3Fclient_id%3Doauth2-proxy%26post_logout_redirect_uri%3Dhttps%253A%252F%252F[DSPORTAL_FQDN]
 AUTHORITY_PORTAL_FRONTEND_LOGOUT_URL: (...) # Auth Proxy: Logout URL
-AUTHORITY_PORTAL_FRONTEND_INVALIDATE_SESSION_COOKIES_URL: https://[AP_FQDN]/oauth2/sign_out # Auth Proxy: URL to invalidate sessions cookies
+AUTHORITY_PORTAL_FRONTEND_INVALIDATE_SESSION_COOKIES_URL: https://[DSPORTAL_FQDN]/oauth2/sign_out # Auth Proxy: URL to invalidate sessions cookies
 AUTHORITY_PORTAL_FRONTEND_LEGAL_NOTICE_URL: https://yourdataspace.com/legal-notice # Legal Notice URL
 AUTHORITY_PORTAL_FRONTEND_PRIVACY_POLICY_URL: https://yourdataspace.com/privacy-policy # Privacy policy URL
 AUTHORITY_PORTAL_FRONTEND_SUPPORT_URL: https://support.yourdataspace.com # Support page URL
 AUTHORITY_PORTAL_FRONTEND_ACTIVE_PROFILE: sovity-open-source # UI Branding profile (sovity-open-source)
 AUTHORITY_PORTAL_FRONTEND_DATASPACE_SHORT_NAME: ExDS # Short Dataspace name, used in some explanatory texts
-AUTHORITY_PORTAL_FRONTEND_PORTAL_DISPLAY_NAME: "Authority Portal" # Portal name displayed in various texts
+AUTHORITY_PORTAL_FRONTEND_PORTAL_DISPLAY_NAME: "Data Space Portal" # Portal name displayed in various texts
 AUTHORITY_PORTAL_FRONTEND_ENABLE_DASHBOARD: true # Enables or disables the status uptime dashboard
 # Direct URL to the UPDATE_PASSWORD required action in Keycloak
-AUTHORITY_PORTAL_FRONTEND_UPDATE_PASSWORD_URL: https://[KC_FQDN]/realms/authority-portal/protocol/openid-connect/auth?response_type=code&client_id=oauth2-proxy&scope=openid&kc_action=UPDATE_PASSWORD&redirect_uri=https%3A%2F%2F[AP_FQDN]%2Foauth2%2Fcallback
+AUTHORITY_PORTAL_FRONTEND_UPDATE_PASSWORD_URL: https://[KC_FQDN]/realms/authority-portal/protocol/openid-connect/auth?response_type=code&client_id=oauth2-proxy&scope=openid&kc_action=UPDATE_PASSWORD&redirect_uri=https%3A%2F%2F[DSPORTAL_FQDN]%2Foauth2%2Fcallback
 
 ```
 
@@ -351,10 +351,10 @@ Although it is discouraged to do so, the expected value `broker` could be overri
 # Required: Fully Qualified Domain Name
 MY_EDC_FQDN: "crawler.test.example.com"
 
-# Required: Authority Portal Environment ID
+# Required: Data Space Portal Environment ID
 CRAWLER_ENVIRONMENT_ID: test
 
-# Required: Authority Portal Postgresql DB Access
+# Required: Data Space Portal Postgresql DB Access
 CRAWLER_DB_JDBC_URL: jdbc:postgresql://authority-portal:5432/portal
 CRAWLER_DB_JDBC_USER: portal
 CRAWLER_DB_JDBC_PASSWORD: portal

--- a/docs/product/user-documentation/Authority Section.md
+++ b/docs/product/user-documentation/Authority Section.md
@@ -10,7 +10,7 @@ Organization management is only available to Authority Admins and Authority User
 
 ![organizations-page](images/organizations-list.png)
 
-On the Organization page you can see all organizations registered in the Authority Portal. They can be filtered by:
+On the Organization page you can see all organizations registered in the Data Space Portal. They can be filtered by:
 
 - _Active_: Fully registered organizations
 - _Invited_: Organization invitation has been sent, but was not yet accepted
@@ -46,12 +46,12 @@ The process is as follows:
 
 ## Connector overview
 
-Under "All Connectors", Authority Users and Admins can see all registered connectors of all organizations in the Authority Portal.
+Under "All Connectors", Authority Users and Admins can see all registered connectors of all organizations in the Data Space Portal.
 Also, the connector details can be accessed from here.
 
 Additionally, the status of each connector is displayed, providing insights into their current operational state. Each Connector can have the following statuses:
 - Online: The connector is reachable and operational.
-- Offline: The connector is not reachable by the Authority Portal crawler.
+- Offline: The connector is not reachable by the Data Space Portal crawler.
 
 Connectors of type CAAS (Connector as a Service) can also support extended operational statuses. These additional statuses provide more granular insights into the state of Connector as a Service Connectors, reflecting their dynamic and managed nature.
 - Init: The connector is in the initialization process.

--- a/docs/product/user-documentation/General Overview.md
+++ b/docs/product/user-documentation/General Overview.md
@@ -8,13 +8,13 @@ This guide provides a general overview of the main sections and features of the 
 
 ## Navigation Overview
 
-The Authority Portal is structured into six main sections, each serving a distinct purpose. You can access each section from the left navigation panel. Below is a brief description of each:
+The Data Space Portal is structured into six main sections, each serving a distinct purpose. You can access each section from the left navigation panel. Below is a brief description of each:
 
 ### 1. Home
-The Home section is your landing page within the Authority Portal if no direct links are used. It provides an overview of the system with the Dashboard and quick access to the Data Catalog.
+The Home section is your landing page within the Data Space Portal if no direct links are used. It provides an overview of the system with the Dashboard and quick access to the Data Catalog.
 
 #### Data Catalog
-The Data Catalog of the Authority Portal is designed to allow you to browse a comprehensive list of data offers available within a data space. It serves as a centralized interface where participants can discover, access, and evaluate various data offers.
+The Data Catalog of the Data Space Portal is designed to allow you to browse a comprehensive list of data offers available within a data space. It serves as a centralized interface where participants can discover, access, and evaluate various data offers.
 
 #### Dashboard
 The Dashboard provides a snapshot of the current status and uptime history of the components in the data space. It is a central place to monitor key indicators, like online and offline status of connectors, online status of the DAPS, the Logging House or the Catalog Crawler.
@@ -51,7 +51,7 @@ This section enables the service parnter with direct access to all provided conn
 **To learn more about the Service Partner Admin role, please read the section [Application role: Service Partner Admin](Manage%20Data%20Space%20components.md#application-role-service-partner-admin).**
 
 ### 5. Authority Section
-This section is intended for administrators of the data space and includes advanced features for managing the authority portal and the organizations in the data space.
+This section is intended for administrators of the data space and includes advanced features for managing the Data Space Portal and the organizations in the data space.
 
 #### Organizations
 As a data space authority, all organizations registered in the data space can be viewed and managed here. New organizations can also be invited.
@@ -62,4 +62,4 @@ This is a central point for viewing all connectors and their status and further 
 **To learn more about the Authority section, please read the documentation: [Authority Section](Authority%20Section.md).**
 
 ### 6. Support
-The Support section is intended to assist users with any issues or inquiries they might have while using the Authority Portal. Please note that this section requires integration with a support system of your choice to be fully functional.
+The Support section is intended to assist users with any issues or inquiries they might have while using the Data Space Portal. Please note that this section requires integration with a support system of your choice to be fully functional.

--- a/docs/product/user-documentation/Manage Data Space components.md
+++ b/docs/product/user-documentation/Manage Data Space components.md
@@ -14,7 +14,7 @@ Besides the Data Space Authority roles, there are two other application roles th
 ### General
 
 The Service Partner Admin is an application role to represent the provider of connectors in a Data Space. A service partner of a Data Space provides connectors for Data Space participants by deploying and registering these connectors for other entities within the Data Space.
-As such, the service partner has direct access to all provided connectors and the application role of Service Partner Admin aims to mirror those capabilities within the Authority Portal.
+As such, the service partner has direct access to all provided connectors and the application role of Service Partner Admin aims to mirror those capabilities within the Data Space Portal.
 The Service Partner Admin role is an application role and assigned to certain users individually by Authority Admins.
 
 ### Rights for Service Partner Admins
@@ -41,13 +41,13 @@ When clicking on the button "Provide Connector" in the upper right corner a mask
 
 ![provide-connector](images/provide-connector.png)
 
-To provide a connector in the Authority Portal all fields of the mask must be submitted.
+To provide a connector in the Data Space Portal all fields of the mask must be submitted.
 After clicking on the "Create Connector" the list of provided connectors appears, where an added connector can be found which has to be configured further at some point in time.
 
 ![provide-connector](images/provide-connectors-list.png)
 
 By clicking in the list on "Configure", the additional data for the connector must be entered, such as the URL at which the frontend of the connector can be accessed.
-The most important entry  is the connector endpoint, the DSP-endpoint, so that the connector's offers can be searched and displayed in the authority portal, since the authority portal also crawls the connectors in the dataspace for available offers which the authority portal's crawler is allowed to access.
+The most important entry  is the connector endpoint, the DSP-endpoint, so that the connector's offers can be searched and displayed in the Data Space Portal, since the Data Space Portal also crawls the connectors in the dataspace for available offers which the Data Space Portal's crawler is allowed to access.
 The process of the further configuration guides you through the necessary steps and needed information to specify the URLs or enter valid information about the connector certificate.
 Please follow the steps in the dialog.
 
@@ -63,7 +63,7 @@ Please follow the steps in the dialog.
 
 ### General
 
-The Operator Admin is an application role to represent the operator of the Mobility Data Space. The operator of the Mobility Data Space deploys the central components of the Data Space in the infrastructure and manages the different environments of the Data Space. As such, the operator has direct access to all central components and the application role of Operator Admin aims to mirror those capabilities within the Authority Portal.
+The Operator Admin is an application role to represent the operator of the Mobility Data Space. The operator of the Mobility Data Space deploys the central components of the Data Space in the infrastructure and manages the different environments of the Data Space. As such, the operator has direct access to all central components and the application role of Operator Admin aims to mirror those capabilities within the Data Space Portal.
 The Operator Admin role is an application role and assigned to certain users individually by Authority Admins.
 
 ### Rights for Operator Admins
@@ -86,7 +86,7 @@ When clicking on the button "Provide Central Component" in the upper right corne
 
 ![provide-central-component](images/provide-central-component.png)
 
-To register a central component in the Authority Portal all fields of the mask must be submitted.
+To register a central component in the Data Space Portal all fields of the mask must be submitted.
 After clicking on the register button the list of central components appears, where the added central component can be found.
 
 #### 3. Assign Operator Admin role to users within own organization


### PR DESCRIPTION
_What issues does this PR close?_
Changes all documentation I could find from **Authority Portal (AP)** to new **Data Space Portal (DSPortal)** naming.

```[tasklist]
### Checklist
- [x] The PR title is short and expressive.
- [ ] I have updated the CHANGELOG.md and linked the changes to their issues. See [changelog_update.md](https://github.com/sovity/authority-portal/blob/main/docs/dev/changelog_updates.md) for more information.
- [ ] I have updated the Deployment Migration Notes Section in the CHANGELOG.md for any configuration / external API changes.
- [x] I have performed a **self-review**
```
